### PR TITLE
Fix EN_SourceCode/script.txt

### DIFF
--- a/EN_SourceCode/script.txt
+++ b/EN_SourceCode/script.txt
@@ -12,7 +12,7 @@
 // Dirtie, S3v3nx3, BRPXQZME, Iq 132, 4ppleseed, Samutz, DarthNemesis, pelrun, Shaffy, Tickflow
 //
 #VAR(tbl, TABLE)
-#ADDTBL("EN_SourceCode/sjis_2.tbl", tbl)
+#ADDTBL("sjis_2.tbl", tbl)
 #ACTIVETBL(tbl)
 //
 // Pointers for GBA are linear 32bit starting at $8000000


### PR DESCRIPTION
When I tried to run the compile script on the latest master version, I had the issue of Atlas hanging just after parsing. I looked through the recent changes to the script and saw this line was changed. I tried changing the line back, and the patch worked fine. I think the issue is that, when the script file was moved, it was assumed that the TBL path was relative to the working directory (i.e. the BAT directory), when it's actually relative to the script's directory.